### PR TITLE
Add multistage-build Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM clux/muslrust:1.50.0-stable as builder
+WORKDIR /volume
+COPY . .
+RUN cargo build --release
+
+FROM scratch
+COPY --from=builder /volume/target/x86_64-unknown-linux-musl/release/amqp2elastic .
+ENTRYPOINT [ "/amqp2elastic" ]


### PR DESCRIPTION
Build a Docker image containing the statically-linked Rust binary. A
muslrust image is used as the builder image as it compiles openssl and
links it against musl, which is needed to create the statically-linked
binary. The application image is based on a scratch image containing just
that binary.